### PR TITLE
Reduce bundle size of Tailwind CSS and dismiss the warning

### DIFF
--- a/hosting/tailwind.config.js
+++ b/hosting/tailwind.config.js
@@ -1,9 +1,14 @@
 module.exports = {
   future: {
     // removeDeprecatedGapUtilities: true,
-    // purgeLayersByDefault: true,
+    purgeLayersByDefault: true,
   },
-  purge: [],
+  purge: {
+    mode: 'all',
+    content: [
+      './src/**/*.vue',
+    ],
+  },
   theme: {
     extend: {},
   },

--- a/hosting/vue.config.js
+++ b/hosting/vue.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  configureWebpack: {
+    performance: {
+      maxAssetSize: 2_097_152,  // 2 MiB
+      maxEntrypointSize: 2_097_152,  // 2 MiB
+    },
+  },
+};


### PR DESCRIPTION
#### dist/css/app.[hash].css
||Size|Gzipped|
|---|---|---|
|Before|1884.00 KiB|189.58 KiB|
|After|4.21 KiB|1.54 KiB|
